### PR TITLE
Add quotes before and after $BLADE_EXE

### DIFF
--- a/app/util.b
+++ b/app/util.b
@@ -15,7 +15,7 @@ def setup_cli(name, base_path, cli_path) {
       '\n'+ 
       'BLADE_EXE=`which blade`\n' +
       '\n' +
-      'exec $BLADE_EXE "${cli_path}" "$@"\n'
+      'exec "$BLADE_EXE" "${cli_path}" "$@"\n'
   } else {
 
     cmd = '@ECHO OFF\r\n' +
@@ -41,7 +41,7 @@ def setup_cli(name, base_path, cli_path) {
       '\r\n' +
       ':RUN\r\n' +
       '\r\n' +
-      '%BLADE_EXE% "${cli_path}" %*\r\n' +
+      '"%BLADE_EXE%" "${cli_path}" %*\r\n' +
       'EXIT /B 0\r\n'
   }
 


### PR DESCRIPTION
Add quotes before and after $BLADE_EXE to prevent the program from be having unexpectedly when $BLADE_EXE contains whitespace.